### PR TITLE
qa: remove cache dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Removed
 
-- Nothing.
+- Remove `laminas/laminas-cache` dependency to avoid circular dependencies.
 
 ### Fixed
 

--- a/composer.json
+++ b/composer.json
@@ -1,53 +1,55 @@
 {
-    "name": "laminas/laminas-cache-storage-adapter-apc",
-    "description": "Laminas cache adapter",
-    "license": "BSD-3-Clause",
-    "keywords": [
-        "laminas",
-        "cache"
-    ],
-    "support": {
-        "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apc/",
-        "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apc/issues",
-        "source": "https://github.com/laminas/laminas-cache-storage-adapter-apc",
-        "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apc/releases.atom",
-        "forum": "https://discourse.laminas.dev/"
-    },
-    "require": {
-        "php": "^5.6 || ^7.0",
-        "laminas/laminas-cache": "^2.10@dev"
-    },
-    "require-dev": {
-        "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-        "laminas/laminas-coding-standard": "~1.0.0",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
-    },
-    "provide": {
-        "laminas/laminas-cache-storage-implementation": "1.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Laminas\\Cache\\Storage\\Adapter\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "LaminasTest\\Cache\\Storage\\Adapter\\": "test/unit",
-            "LaminasTest\\Cache\\Psr\\": "test/integration/Psr"
-        }
-    },
-    "extra": {
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "suggest": {
-        "ext-apc": "APC or compatible extension, to use the APC storage adapter"
-    },
-    "scripts": {
-        "cs-check": "phpcs",
-        "cs-fix": "phpcbf",
-        "test": "phpunit --colors=always",
-        "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+  "name": "laminas/laminas-cache-storage-adapter-apc",
+  "description": "Laminas cache adapter",
+  "license": "BSD-3-Clause",
+  "keywords": [
+    "laminas",
+    "cache"
+  ],
+  "support": {
+    "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apc/",
+    "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apc/issues",
+    "source": "https://github.com/laminas/laminas-cache-storage-adapter-apc",
+    "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apc/releases.atom",
+    "forum": "https://discourse.laminas.dev/"
+  },
+  "require": {
+    "php": "^5.6 || ^7.0"
+  },
+  "require-dev": {
+    "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
+    "laminas/laminas-coding-standard": "~1.0.0",
+    "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+    "laminas/laminas-cache": "^2.10"
+  },
+  "provide": {
+    "laminas/laminas-cache-storage-implementation": "1.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Laminas\\Cache\\Storage\\Adapter\\": "src/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "LaminasTest\\Cache\\Storage\\Adapter\\": "test/unit",
+      "LaminasTest\\Cache\\Psr\\": "test/integration/Psr"
+    }
+  },
+  "extra": {},
+  "config": {
+    "sort-packages": true
+  },
+  "suggest": {
+    "ext-apc": "APC or compatible extension, to use the APC storage adapter"
+  },
+  "scripts": {
+    "cs-check": "phpcs",
+    "cs-fix": "phpcbf",
+    "test": "phpunit --colors=always",
+    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
+  },
+  "conflict": {
+    "laminas/laminas-cache": "<2.10"
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,30 +1,33 @@
 {
   "name": "laminas/laminas-cache-storage-adapter-apc",
   "description": "Laminas cache adapter",
-  "license": "BSD-3-Clause",
   "keywords": [
     "laminas",
     "cache"
   ],
-  "support": {
-    "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apc/",
-    "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apc/issues",
-    "source": "https://github.com/laminas/laminas-cache-storage-adapter-apc",
-    "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apc/releases.atom",
-    "forum": "https://discourse.laminas.dev/"
-  },
+  "license": "BSD-3-Clause",
   "require": {
     "php": "^5.6 || ^7.0"
   },
-  "require-dev": {
-    "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
-    "laminas/laminas-coding-standard": "~1.0.0",
-    "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-    "laminas/laminas-cache": "^2.10"
+  "conflict": {
+    "laminas/laminas-cache": "<2.10"
   },
   "provide": {
     "laminas/laminas-cache-storage-implementation": "1.0"
   },
+  "require-dev": {
+    "laminas/laminas-cache": "^2.10",
+    "laminas/laminas-cache-storage-adapter-test": "^1.0@dev",
+    "laminas/laminas-coding-standard": "~1.0.0",
+    "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+  },
+  "suggest": {
+    "ext-apc": "APC or compatible extension, to use the APC storage adapter"
+  },
+  "config": {
+    "sort-packages": true
+  },
+  "extra": {},
   "autoload": {
     "psr-4": {
       "Laminas\\Cache\\Storage\\Adapter\\": "src/"
@@ -36,20 +39,17 @@
       "LaminasTest\\Cache\\Psr\\": "test/integration/Psr"
     }
   },
-  "extra": {},
-  "config": {
-    "sort-packages": true
-  },
-  "suggest": {
-    "ext-apc": "APC or compatible extension, to use the APC storage adapter"
-  },
   "scripts": {
     "cs-check": "phpcs",
     "cs-fix": "phpcbf",
     "test": "phpunit --colors=always",
     "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
   },
-  "conflict": {
-    "laminas/laminas-cache": "<2.10"
+  "support": {
+    "issues": "https://github.com/laminas/laminas-cache-storage-adapter-apc/issues",
+    "forum": "https://discourse.laminas.dev/",
+    "source": "https://github.com/laminas/laminas-cache-storage-adapter-apc",
+    "docs": "https://docs.laminas.dev/laminas-cache-storage-adapter-apc/",
+    "rss": "https://github.com/laminas/laminas-cache-storage-adapter-apc/releases.atom"
   }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

Removing `laminas/laminas-cache` dependency to avoid circular dependency conflicts.