### PR TITLE
bugfix: setup `pre-install.sh` to set proper `COMPOSER_ROOT_VERSION`

### DIFF
--- a/.ci/apcu_bc.ini
+++ b/.ci/apcu_bc.ini
@@ -1,3 +1,0 @@
-extension=apcu.so
-extension=apc.so
-apc.enable_cli = 1

--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,9 @@
+{
+    "extensions": [],
+    "ini": [
+        "apc.enable_cli=1"
+    ],
+    "checks": [],
+    "additional_checks": [],
+    "exclude": []
+}

--- a/.laminas-ci/apcu-backward-compatibility.sh
+++ b/.laminas-ci/apcu-backward-compatibility.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -l
+
+PHP=$1
+PACKAGE=php${PHP}-apcu-bc
+
+if [[ "${PHP}" =~ ^5. ]];then
+    PACKAGE=php${PHP}-apcu
+fi
+
+apt install -y $PACKAGE
+echo "Enabling apc for ${PHP} cli"
+phpenmod -v ${PHP} -s cli apc
+

--- a/.laminas-ci/composer-root-version.sh
+++ b/.laminas-ci/composer-root-version.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -l
+
+if [[ -z "${GITHUB_BASE_REF}" ]]; then
+    echo "Environment variable \"GITHUB_BASE_REF\" does not exist."
+
+    exit 0
+fi
+
+BRANCH_REGEX="[0-9]+\.[0-9]+\.x"
+
+if ! [[ "${GITHUB_BASE_REF}" =~ ${BRANCH_REGEX} ]]; then
+    echo "Environment variable \"GITHUB_BASE_REF\" does not match expectations."
+    echo "Must match ${BRANCH_REGEX}";
+
+    exit 0
+fi
+
+COMPOSER_ROOT_VERSION=$(echo ${GITHUB_BASE_REF} | sed 's/\.x/\.99/g')
+
+echo "Determined composer root version as \"${COMPOSER_ROOT_VERSION}\"."
+
+if [[ true = "${GITHUB_ACTIONS}" ]]; then
+    echo "Setting COMPOSER_ROOT_VERSION environment variable to \"${COMPOSER_ROOT_VERSION}\"."
+    if [ ! -w "${GITHUB_ENV}" ]; then
+        echo "Missing GITHUB_ENV environment variable. Cannot store COMPOSER_ROOT_VERSION to be available within the current check."
+        exit 1
+    fi
+    echo "COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION}" >> "${GITHUB_ENV}"
+fi

--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+WORKING_DIRECTORY=$2
+JOB=$3
+PHP_VERSION=$(echo "${JOB}" | jq -r '.php')
+
+${WORKING_DIRECTORY}/.laminas-ci/composer-root-version.sh || exit 1
+${WORKING_DIRECTORY}/.laminas-ci/apcu-backward-compatibility.sh ${PHP_VERSION} || exit 1

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "laminas/laminas-cache-storage-implementation": "1.0"
   },
   "require-dev": {
+    "ext-apc": "*",
     "laminas/laminas-cache": "^2.10",
     "laminas/laminas-cache-storage-adapter-test": "^1.0.2",
     "laminas/laminas-coding-standard": "~1.0.0",

--- a/test/integration/Psr/CacheItemPool/ApcIntegrationTest.php
+++ b/test/integration/Psr/CacheItemPool/ApcIntegrationTest.php
@@ -34,10 +34,6 @@ class ApcIntegrationTest extends CachePoolTest
 
     protected function setUp()
     {
-        if (! getenv('TESTS_LAMINAS_CACHE_APC_ENABLED')) {
-            $this->markTestSkipped('Enable TESTS_LAMINAS_CACHE_APC_ENABLED to run this test');
-        }
-
         // set non-UTC timezone
         $this->tz = date_default_timezone_get();
         date_default_timezone_set('America/Vancouver');

--- a/test/integration/Psr/SimpleCache/ApcIntegrationTest.php
+++ b/test/integration/Psr/SimpleCache/ApcIntegrationTest.php
@@ -31,10 +31,6 @@ class ApcIntegrationTest extends SimpleCacheTest
 
     protected function setUp()
     {
-        if (! getenv('TESTS_LAMINAS_CACHE_APC_ENABLED')) {
-            $this->markTestSkipped('Enable TESTS_LAMINAS_CACHE_APC_ENABLED to run this test');
-        }
-
         // set non-UTC timezone
         $this->tz = date_default_timezone_get();
         date_default_timezone_set('America/Vancouver');

--- a/test/unit/ApcTest.php
+++ b/test/unit/ApcTest.php
@@ -25,10 +25,6 @@ class ApcTest extends CommonAdapterTest
 
     public function setUp()
     {
-        if (getenv('TESTS_LAMINAS_CACHE_APC_ENABLED') != 'true') {
-            $this->markTestSkipped('Enable TESTS_LAMINAS_CACHE_APC_ENABLED to run this test');
-        }
-
         try {
             new Cache\Storage\Adapter\Apc();
         } catch (Cache\Exception\ExtensionNotLoadedException $e) {


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With the merge-up from 1.0.x, we have circular dependencies in this project.
To avoid this, we need to set `COMPOSER_ROOT_VERSION` to the environment so that composer understands the version of this package.

This PR depends on 1.5.0 of https://github.com/laminas/laminas-continuous-integration-action and thus the build may fail for the time being.