### PR TITLE
 Add PHP 8.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,20 +7,17 @@
   ],
   "license": "BSD-3-Clause",
   "require": {
-    "php": "^5.6 || ^7.0"
-  },
-  "conflict": {
-    "laminas/laminas-cache": "<2.10"
+    "php": "^7.3 || ~8.0.0"
   },
   "provide": {
     "laminas/laminas-cache-storage-implementation": "1.0"
   },
   "require-dev": {
     "ext-apc": "*",
-    "laminas/laminas-cache": "^2.10",
-    "laminas/laminas-cache-storage-adapter-test": "^1.0.2",
+    "laminas/laminas-cache": "^2.11",
+    "laminas/laminas-cache-storage-adapter-test": "^1.1.1",
     "laminas/laminas-coding-standard": "~1.0.0",
-    "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+    "phpunit/phpunit": "^9.5.4"
   },
   "suggest": {
     "ext-apc": "APC or compatible extension, to use the APC storage adapter"

--- a/test/integration/Psr/CacheItemPool/ApcIntegrationTest.php
+++ b/test/integration/Psr/CacheItemPool/ApcIntegrationTest.php
@@ -32,7 +32,7 @@ class ApcIntegrationTest extends CachePoolTest
      */
     protected $iniUseRequestTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // set non-UTC timezone
         $this->tz = date_default_timezone_get();
@@ -45,7 +45,7 @@ class ApcIntegrationTest extends CachePoolTest
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         date_default_timezone_set($this->tz);
 
@@ -59,12 +59,10 @@ class ApcIntegrationTest extends CachePoolTest
         parent::tearDown();
     }
 
-    /**
-     * @expectedException \Laminas\Cache\Psr\CacheItemPool\CacheException
-     */
     public function testApcUseRequestTimeThrowsException()
     {
         ini_set('apc.use_request_time', 1);
+        $this->expectException(\Laminas\Cache\Psr\CacheItemPool\CacheException::class);
         $this->createCachePool();
     }
 

--- a/test/integration/Psr/SimpleCache/ApcIntegrationTest.php
+++ b/test/integration/Psr/SimpleCache/ApcIntegrationTest.php
@@ -29,7 +29,7 @@ class ApcIntegrationTest extends SimpleCacheTest
      */
     protected $iniUseRequestTime;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         // set non-UTC timezone
         $this->tz = date_default_timezone_get();
@@ -42,7 +42,7 @@ class ApcIntegrationTest extends SimpleCacheTest
         parent::setUp();
     }
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         date_default_timezone_set($this->tz);
 

--- a/test/unit/ApcTest.php
+++ b/test/unit/ApcTest.php
@@ -14,7 +14,7 @@ use Laminas\Cache;
  * @group      Laminas_Cache
  * @covers Laminas\Cache\Storage\Adapter\Apc<extended>
  */
-class ApcTest extends CommonAdapterTest
+class ApcTest extends AbstractCommonAdapterTest
 {
     /**
      * Restore 'apc.use_request_time'
@@ -23,7 +23,7 @@ class ApcTest extends CommonAdapterTest
      */
     protected $iniUseRequestTime;
 
-    public function setUp()
+    public function setUp(): void
     {
         try {
             new Cache\Storage\Adapter\Apc();
@@ -35,14 +35,14 @@ class ApcTest extends CommonAdapterTest
         $this->iniUseRequestTime = ini_get('apc.use_request_time');
         ini_set('apc.use_request_time', 0);
 
-        $this->_options = new Cache\Storage\Adapter\ApcOptions();
-        $this->_storage = new Cache\Storage\Adapter\Apc();
-        $this->_storage->setOptions($this->_options);
+        $this->options = new Cache\Storage\Adapter\ApcOptions();
+        $this->storage = new Cache\Storage\Adapter\Apc();
+        $this->storage->setOptions($this->_options);
 
         parent::setUp();
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         if (function_exists('apc_clear_cache')) {
             apc_clear_cache('user');


### PR DESCRIPTION
 Add PHP 8.0 support

 * [x]  Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
 * [x]  Modify composer.json to drop support for PHP less than 7.3
 * [x ]  Modify composer.json to implement phpunit 9.3 which supports PHP 7.3+
 * [x]  Modify source code in case there are incompatibilities with PHP 8.0


 The build is now working.